### PR TITLE
Add "license" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Vue.js Clipboard Plugin",
   "version": "2.2.2",
   "author": "euvl <yev.vlasenko@gmail.com>",
+  "license": "MIT",
   "private": false,
   "types": "src/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This package is MIT licensed, so add that to the package.json file, to make it easier for license compliance/scanner tools to find it.