### PR TITLE
Fixed configuration of success handler

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -25,7 +25,7 @@ export const ClipboardPlugin: Plugin = {
           return
         }
 
-        if (arg === 'error' && isFn) {
+        if (arg === 'success' && isFn) {
           el.dataset.clipboardSuccess = cache.add(value)
           return
         }


### PR DESCRIPTION
`v-clipboard:success` did not work correctly, but was instead interpreted as just a `v-clipboard`. As long as you did not return anything from this function this still worked, but resulted in a "Clipboard input is empty" log entry.
