### PR TITLE
Fix clipboard copy on iOS 18.4+ by enforcing real selection with focus

### DIFF
--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -44,6 +44,8 @@ export const Clipboard = {
       if (selection) {
         selection.removeAllRanges()
         selection.addRange(range)
+
+        textarea.focus() // Required by iOS 18.4+: https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes#Resolved-Issues
         textarea.setSelectionRange(0, 999999)
       }
     } else {


### PR DESCRIPTION
This PR fixes clipboard copying on iOS 18.4 and later, where `document.execCommand('copy')` silently fails if no real text selection is present.

Starting with iOS 18.4, Safari requires the target element to be focused and a selection to be explicitly set in order for the `execCommand('copy')` operation to succeed. This behavior change is documented in the [Safari 18.4 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes), which states:

> Fixed `document.execCommand("copy")` only triggering if there is a selection.

This update modifies the fallback logic used for copying on iOS by adding:

```js
textarea.focus();
textarea.setSelectionRange(0, 999999);
```

These lines ensure that the copy operation works as expected under the new requirement.

## What was changed

- Added `textarea.focus()` before `setSelectionRange(...)` inside the iOS-specific branch of the clipboard fallback logic.
- No other parts of the logic were modified.

## How to reproduce

On an iOS 18.4+ device or simulator:

1. Attempt to copy text using `execCommand('copy')` without focusing or selecting the element.
2. Observe that the operation returns `true` but does not actually copy the value.
3. After applying this fix, the text is properly copied to the clipboard.

## Related

- Safari 18.4 Release Notes: https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes
